### PR TITLE
PDF2IMG-173: Add initial GitHub Actions workflow for NuGet package testing

### DIFF
--- a/.github/workflows/test-nuget-samples.yml
+++ b/.github/workflows/test-nuget-samples.yml
@@ -1,0 +1,20 @@
+name: test-nuget-package-with-samples
+
+on:
+    pull_request:
+    push:
+        branches: [ develop ]
+
+env:
+    DOTNET_VERSION: '6.x'
+
+jobs:
+    build-and-run-samples:
+        runs-on: windows-2022
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v3
+              with:
+                dotnet-version: ${{ env.DOTNET_VERSION }}


### PR DESCRIPTION
Let's add a GitHub Actions workflow, so that we can ensure that the NuGet package can be used to run the samples.